### PR TITLE
Remove bad assumption

### DIFF
--- a/ios/Interactable/InteractableView.m
+++ b/ios/Interactable/InteractableView.m
@@ -327,6 +327,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (BOOL)gestureRecognizerShouldBegin:(UIPanGestureRecognizer *)pan
 {
+    if (![pan isKindOfClass:[UIPanGestureRecognizer class]]) return YES;
+    
     CGPoint translation = [pan translationInView:self];
     if (self.horizontalOnly) return fabs(translation.x) > fabs(translation.y);
     if (self.verticalOnly) return fabs(translation.y) > fabs(translation.x);


### PR DESCRIPTION
When the InteractableView is positioned along the bottom of the screen
intermittently, it seems, `- gestureRecognizerShouldBegin:` will be called
with a system gesture recognizer related to the sytem Control Center. This
can cause a crash since the system gesture recognizer does not implemnt
`- translationInView:`.